### PR TITLE
feat: add __repr__/__str__ and serialization to core classes

### DIFF
--- a/se3kit/hpoint.py
+++ b/se3kit/hpoint.py
@@ -132,6 +132,58 @@ class HPoint:
         """
         return self.m.copy()
 
+    def to_dict(self):
+        """
+        Serializes the homogeneous point to a plain Python dictionary.
+
+        :return: Dictionary with keys 'type' and 'xyz'.
+        :rtype: dict
+        """
+        return {
+            "type": "HPoint",
+            "xyz": [float(self.x), float(self.y), float(self.z)],
+        }
+
+    @staticmethod
+    def from_dict(d):
+        """
+        Constructs an HPoint from a dictionary.
+
+        :param d: Dictionary with 'xyz' key (3-element list).
+        :type d: dict
+        :return: HPoint object.
+        :rtype: HPoint
+        :raises ValueError: If 'xyz' key is missing.
+        """
+        if "xyz" in d:
+            return HPoint(d["xyz"])
+        raise ValueError("Dict must contain 'xyz' key")
+
+    def to_json(self, indent=2):
+        """
+        Serializes the homogeneous point to a JSON string.
+
+        :param indent: JSON indentation level, defaults to 2.
+        :type indent: int
+        :return: JSON string.
+        :rtype: str
+        """
+        import json
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @staticmethod
+    def from_json(json_str):
+        """
+        Constructs an HPoint from a JSON string.
+
+        :param json_str: JSON string containing point data.
+        :type json_str: str
+        :return: HPoint object.
+        :rtype: HPoint
+        """
+        import json
+        return HPoint.from_dict(json.loads(json_str))
+
     def __repr__(self):
         """
         Official string representation of the HPoint object.

--- a/se3kit/rotation.py
+++ b/se3kit/rotation.py
@@ -443,6 +443,174 @@ class Rotation:
         w = skew_to_vector((self.m - self.m.T) / (2 * np.sin(theta)))
         return w, (theta if not degrees else rad2deg(theta))
 
+    def __repr__(self):
+        """
+        Official string representation of the Rotation object.
+
+        Returns a string that can reconstruct the object via eval() when numpy is imported.
+
+        :return: Reconstructable string representation.
+        :rtype: str
+        """
+        matrix_str = np.array2string(self.m, separator=', ')
+        return f"Rotation(np.array({matrix_str}))"
+
+    def __str__(self):
+        """
+        Human-friendly string representation showing RPY angles in degrees.
+
+        :return: Formatted string with roll, pitch, yaw in degrees.
+        :rtype: str
+        """
+        rpy = self.as_rpy(degrees=True)
+        return f"Rotation(rpy_deg=[{rpy[0]:.6f}, {rpy[1]:.6f}, {rpy[2]:.6f}])"
+
+    def to_dict(self):
+        """
+        Serializes the rotation to a plain Python dictionary.
+
+        Includes the rotation matrix, quaternion (xyzw), and RPY angles (radians)
+        so consumers can pick whichever representation they need.
+
+        :return: Dictionary with keys 'type', 'quaternion_xyzw', 'rpy_rad', 'matrix'.
+        :rtype: dict
+        """
+        q = self.as_quat()
+        rpy = self.as_rpy()
+        return {
+            "type": "Rotation",
+            "quaternion_xyzw": [float(q.x), float(q.y), float(q.z), float(q.w)],
+            "rpy_rad": [float(rpy[0]), float(rpy[1]), float(rpy[2])],
+            "matrix": self.m.tolist(),
+        }
+
+    @staticmethod
+    def from_dict(d):
+        """
+        Constructs a Rotation from a dictionary.
+
+        Checks for keys in order of fidelity: 'matrix' (lossless) > 'quaternion_xyzw' > 'rpy_rad'.
+
+        :param d: Dictionary with rotation data.
+        :type d: dict
+        :return: Rotation object.
+        :rtype: Rotation
+        :raises ValueError: If no recognized key is found.
+        """
+        if "matrix" in d:
+            return Rotation(np.array(d["matrix"]))
+        if "quaternion_xyzw" in d:
+            return Rotation.from_quat(d["quaternion_xyzw"])
+        if "rpy_rad" in d:
+            return Rotation.from_rpy(d["rpy_rad"])
+        raise ValueError("Dict must contain 'matrix', 'quaternion_xyzw', or 'rpy_rad'")
+
+    def to_json(self, indent=2):
+        """
+        Serializes the rotation to a JSON string.
+
+        :param indent: JSON indentation level, defaults to 2.
+        :type indent: int
+        :return: JSON string.
+        :rtype: str
+        """
+        import json
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @staticmethod
+    def from_json(json_str):
+        """
+        Constructs a Rotation from a JSON string.
+
+        :param json_str: JSON string containing rotation data.
+        :type json_str: str
+        :return: Rotation object.
+        :rtype: Rotation
+        """
+        import json
+        return Rotation.from_dict(json.loads(json_str))
+
+    def to_csv(self, path, header=True, fmt="quaternion"):
+        """
+        Writes the rotation to a CSV file.
+
+        :param path: File path to write to.
+        :type path: str or pathlib.Path
+        :param header: Whether to write a header row, defaults to True.
+        :type header: bool
+        :param fmt: Output format. One of 'quaternion' (qx,qy,qz,qw), 'rpy_rad',
+            'rpy_deg', or 'matrix' (r00..r22). Defaults to 'quaternion'.
+        :type fmt: str
+        """
+        import csv
+        from pathlib import Path
+
+        path = Path(path)
+        headers, values = self._csv_data(fmt)
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            if header:
+                writer.writerow(headers)
+            writer.writerow(values)
+
+    @staticmethod
+    def from_csv(path, fmt="quaternion"):
+        """
+        Reads a Rotation from the first data row of a CSV file.
+
+        :param path: File path to read from.
+        :type path: str or pathlib.Path
+        :param fmt: Input format matching the CSV columns. One of 'quaternion',
+            'rpy_rad', 'rpy_deg', or 'matrix'. Defaults to 'quaternion'.
+        :type fmt: str
+        :return: Rotation object.
+        :rtype: Rotation
+        """
+        import csv
+        from pathlib import Path
+
+        path = Path(path)
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+
+        # Skip header if first row is non-numeric
+        data_row = rows[0]
+        try:
+            float(data_row[0])
+        except ValueError:
+            data_row = rows[1]
+
+        values = [float(v) for v in data_row]
+
+        if fmt == "quaternion":
+            return Rotation.from_quat(values)  # qx, qy, qz, qw
+        if fmt == "rpy_rad":
+            return Rotation.from_rpy(values)
+        if fmt == "rpy_deg":
+            return Rotation.from_rpy(values, degrees=True)
+        if fmt == "matrix":
+            return Rotation(np.array(values).reshape(3, 3))
+        raise ValueError(f"Unknown format: {fmt}")
+
+    def _csv_data(self, fmt):
+        """Returns (headers, values) for the given CSV format."""
+        if fmt == "quaternion":
+            q = self.as_quat()
+            return ["qx", "qy", "qz", "qw"], [float(q.x), float(q.y), float(q.z), float(q.w)]
+        if fmt == "rpy_rad":
+            rpy = self.as_rpy()
+            return ["roll", "pitch", "yaw"], [float(rpy[0]), float(rpy[1]), float(rpy[2])]
+        if fmt == "rpy_deg":
+            rpy = self.as_rpy(degrees=True)
+            return ["roll_deg", "pitch_deg", "yaw_deg"], [float(rpy[0]), float(rpy[1]), float(rpy[2])]
+        if fmt == "matrix":
+            headers = [f"r{i}{j}" for i in range(3) for j in range(3)]
+            values = [float(self.m[i, j]) for i in range(3) for j in range(3)]
+            return headers, values
+        raise ValueError(f"Unknown format: {fmt}")
+
     @property
     def x_axis(self):
         """

--- a/se3kit/transformation.py
+++ b/se3kit/transformation.py
@@ -297,6 +297,169 @@ class Transformation:
             rotation=self.rotation.as_geometry_orientation(),
         )
 
+    def __repr__(self):
+        """
+        Official string representation of the Transformation object.
+
+        Returns a string that can reconstruct the object via eval() when numpy is imported.
+
+        :return: Reconstructable string representation.
+        :rtype: str
+        """
+        matrix_str = np.array2string(self._matrix, separator=', ')
+        return f"Transformation(np.array({matrix_str}))"
+
+    def __str__(self):
+        """
+        Human-friendly string representation showing translation and RPY angles.
+
+        :return: Formatted multi-line string.
+        :rtype: str
+        """
+        t = self.translation
+        rpy = self.rotation.as_rpy(degrees=True)
+        return (
+            f"Transformation(\n"
+            f"  xyz=[{t.x:.6f}, {t.y:.6f}, {t.z:.6f}],\n"
+            f"  rpy_deg=[{rpy[0]:.6f}, {rpy[1]:.6f}, {rpy[2]:.6f}]\n"
+            f")"
+        )
+
+    def to_dict(self):
+        """
+        Serializes the transformation to a plain Python dictionary.
+
+        Includes the full 4x4 matrix and decomposed translation/rotation sub-dicts.
+
+        :return: Dictionary with keys 'type', 'translation', 'rotation', 'matrix'.
+        :rtype: dict
+        """
+        return {
+            "type": "Transformation",
+            "translation": self.translation.to_dict(),
+            "rotation": self.rotation.to_dict(),
+            "matrix": self._matrix.tolist(),
+        }
+
+    @staticmethod
+    def from_dict(d):
+        """
+        Constructs a Transformation from a dictionary.
+
+        Checks for keys in order of fidelity: 'matrix' (lossless 4x4) > decomposed
+        'translation' + 'rotation'.
+
+        :param d: Dictionary with transformation data.
+        :type d: dict
+        :return: Transformation object.
+        :rtype: Transformation
+        :raises ValueError: If no recognized keys are found.
+        """
+        if "matrix" in d:
+            return Transformation(np.array(d["matrix"]))
+        if "translation" in d and "rotation" in d:
+            return Transformation(
+                Translation.from_dict(d["translation"]),
+                Rotation.from_dict(d["rotation"]),
+            )
+        raise ValueError("Dict must contain 'matrix' or both 'translation' and 'rotation'")
+
+    def to_json(self, indent=2):
+        """
+        Serializes the transformation to a JSON string.
+
+        :param indent: JSON indentation level, defaults to 2.
+        :type indent: int
+        :return: JSON string.
+        :rtype: str
+        """
+        import json
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @staticmethod
+    def from_json(json_str):
+        """
+        Constructs a Transformation from a JSON string.
+
+        :param json_str: JSON string containing transformation data.
+        :type json_str: str
+        :return: Transformation object.
+        :rtype: Transformation
+        """
+        import json
+        return Transformation.from_dict(json.loads(json_str))
+
+    def to_csv(self, path, header=True, rotation_format="quaternion"):
+        """
+        Writes the transformation to a CSV file.
+
+        :param path: File path to write to.
+        :type path: str or pathlib.Path
+        :param header: Whether to write a header row, defaults to True.
+        :type header: bool
+        :param rotation_format: Rotation output format. One of 'quaternion', 'rpy_rad',
+            'rpy_deg', or 'matrix'. Defaults to 'quaternion'.
+        :type rotation_format: str
+        """
+        import csv
+        from pathlib import Path
+
+        path = Path(path)
+        rot_headers, rot_values = self.rotation._csv_data(rotation_format)
+        headers = ["x", "y", "z"] + rot_headers
+        values = [float(self.translation.x), float(self.translation.y), float(self.translation.z)] + rot_values
+
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            if header:
+                writer.writerow(headers)
+            writer.writerow(values)
+
+    @staticmethod
+    def from_csv(path, rotation_format="quaternion"):
+        """
+        Reads a Transformation from the first data row of a CSV file.
+
+        :param path: File path to read from.
+        :type path: str or pathlib.Path
+        :param rotation_format: Rotation input format matching the CSV columns.
+            Defaults to 'quaternion'.
+        :type rotation_format: str
+        :return: Transformation object.
+        :rtype: Transformation
+        """
+        import csv
+        from pathlib import Path
+
+        path = Path(path)
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+
+        # Skip header if first row is non-numeric
+        data_row = rows[0]
+        try:
+            float(data_row[0])
+        except ValueError:
+            data_row = rows[1]
+
+        values = [float(v) for v in data_row]
+        trans = Translation(values[:3])
+        rot_values = values[3:]
+
+        if rotation_format == "quaternion":
+            rot = Rotation.from_quat(rot_values)
+        elif rotation_format == "rpy_rad":
+            rot = Rotation.from_rpy(rot_values)
+        elif rotation_format == "rpy_deg":
+            rot = Rotation.from_rpy(rot_values, degrees=True)
+        elif rotation_format == "matrix":
+            rot = Rotation(np.array(rot_values).reshape(3, 3))
+        else:
+            raise ValueError(f"Unknown rotation format: {rotation_format}")
+
+        return Transformation(trans, rot)
+
     @staticmethod
     def from_xyz_mm_abc(xyz_abc, degrees=False):
         """

--- a/se3kit/translation.py
+++ b/se3kit/translation.py
@@ -258,6 +258,122 @@ class Translation:
             raise ModuleNotFoundError("geometry_msgs module not available")
         return Vector3(x=self.x, y=self.y, z=self.z)
 
+    def __repr__(self):
+        """
+        Official string representation of the Translation object.
+
+        :return: Reconstructable string representation.
+        :rtype: str
+        """
+        return f"Translation([{float(self.m[0])!r}, {float(self.m[1])!r}, {float(self.m[2])!r}])"
+
+    def __str__(self):
+        """
+        Human-friendly string representation.
+
+        :return: Formatted string with xyz values.
+        :rtype: str
+        """
+        return f"Translation(xyz=[{self.m[0]:.6f}, {self.m[1]:.6f}, {self.m[2]:.6f}])"
+
+    def to_dict(self):
+        """
+        Serializes the translation to a plain Python dictionary.
+
+        :return: Dictionary with keys 'type' and 'xyz'.
+        :rtype: dict
+        """
+        return {
+            "type": "Translation",
+            "xyz": [float(self.m[0]), float(self.m[1]), float(self.m[2])],
+        }
+
+    @staticmethod
+    def from_dict(d):
+        """
+        Constructs a Translation from a dictionary.
+
+        :param d: Dictionary with 'xyz' key.
+        :type d: dict
+        :return: Translation object.
+        :rtype: Translation
+        :raises ValueError: If 'xyz' key is missing.
+        """
+        if "xyz" in d:
+            return Translation(d["xyz"])
+        raise ValueError("Dict must contain 'xyz' key")
+
+    def to_json(self, indent=2):
+        """
+        Serializes the translation to a JSON string.
+
+        :param indent: JSON indentation level, defaults to 2.
+        :type indent: int
+        :return: JSON string.
+        :rtype: str
+        """
+        import json
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @staticmethod
+    def from_json(json_str):
+        """
+        Constructs a Translation from a JSON string.
+
+        :param json_str: JSON string containing translation data.
+        :type json_str: str
+        :return: Translation object.
+        :rtype: Translation
+        """
+        import json
+        return Translation.from_dict(json.loads(json_str))
+
+    def to_csv(self, path, header=True):
+        """
+        Writes the translation to a CSV file.
+
+        :param path: File path to write to.
+        :type path: str or pathlib.Path
+        :param header: Whether to write a header row, defaults to True.
+        :type header: bool
+        """
+        import csv
+        from pathlib import Path
+
+        path = Path(path)
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            if header:
+                writer.writerow(["x", "y", "z"])
+            writer.writerow([float(self.m[0]), float(self.m[1]), float(self.m[2])])
+
+    @staticmethod
+    def from_csv(path):
+        """
+        Reads a Translation from the first data row of a CSV file.
+
+        :param path: File path to read from.
+        :type path: str or pathlib.Path
+        :return: Translation object.
+        :rtype: Translation
+        """
+        import csv
+        from pathlib import Path
+
+        path = Path(path)
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+
+        # Skip header if first row is non-numeric
+        data_row = rows[0]
+        try:
+            float(data_row[0])
+        except ValueError:
+            data_row = rows[1]
+
+        return Translation([float(v) for v in data_row])
+
     @staticmethod
     def are_close(trans_1, trans_2, tol=0.001):
         """

--- a/tests/test_repr_str.py
+++ b/tests/test_repr_str.py
@@ -1,0 +1,124 @@
+"""Tests for __repr__ and __str__ methods on all core classes."""
+
+import unittest
+
+import numpy as np
+
+from se3kit.hpoint import HPoint
+from se3kit.rotation import Rotation
+from se3kit.transformation import Transformation
+from se3kit.translation import Translation
+
+
+class TestTranslationReprStr(unittest.TestCase):
+    """Test __repr__ and __str__ for Translation."""
+
+    def test_repr_contains_class_name(self):
+        t = Translation([1.0, 2.0, 3.0])
+        self.assertIn("Translation", repr(t))
+
+    def test_repr_contains_values(self):
+        t = Translation([1.5, -2.5, 3.0])
+        r = repr(t)
+        self.assertIn("1.5", r)
+        self.assertIn("-2.5", r)
+        self.assertIn("3.0", r)
+
+    def test_repr_roundtrip(self):
+        """eval(repr(t)) should reconstruct an equivalent Translation."""
+        t = Translation([0.5, -0.25, 1.0])
+        t2 = eval(repr(t))  # noqa: S307
+        self.assertTrue(Translation.are_close(t, t2, tol=1e-12))
+
+    def test_str_contains_class_name(self):
+        t = Translation([1.0, 2.0, 3.0])
+        self.assertIn("Translation", str(t))
+
+    def test_str_contains_xyz(self):
+        t = Translation([1.0, 2.0, 3.0])
+        self.assertIn("xyz", str(t))
+
+    def test_str_fixed_precision(self):
+        """__str__ should show 6 decimal places."""
+        t = Translation([1.0, 0.0, 0.0])
+        self.assertIn("1.000000", str(t))
+
+    def test_zero_translation(self):
+        t = Translation()
+        s = str(t)
+        self.assertIn("0.000000", s)
+
+
+class TestRotationReprStr(unittest.TestCase):
+    """Test __repr__ and __str__ for Rotation."""
+
+    def test_repr_contains_class_name(self):
+        r = Rotation()
+        self.assertIn("Rotation", repr(r))
+
+    def test_repr_contains_np_array(self):
+        r = Rotation()
+        self.assertIn("np.array", repr(r))
+
+    def test_str_contains_rpy(self):
+        r = Rotation()
+        self.assertIn("rpy_deg", str(r))
+
+    def test_str_identity_shows_zeros(self):
+        r = Rotation()
+        s = str(r)
+        self.assertIn("0.000000", s)
+
+    def test_str_90deg_rotation(self):
+        """A 90-degree Z rotation should show ~90 in the yaw component."""
+        r = Rotation.from_rpy([0, 0, np.pi / 2])
+        s = str(r)
+        self.assertIn("90.0", s)
+
+
+class TestTransformationReprStr(unittest.TestCase):
+    """Test __repr__ and __str__ for Transformation."""
+
+    def test_repr_contains_class_name(self):
+        T = Transformation()
+        self.assertIn("Transformation", repr(T))
+
+    def test_repr_contains_np_array(self):
+        T = Transformation()
+        self.assertIn("np.array", repr(T))
+
+    def test_str_contains_xyz_and_rpy(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation())
+        s = str(T)
+        self.assertIn("xyz", s)
+        self.assertIn("rpy_deg", s)
+
+    def test_str_multiline(self):
+        """__str__ should produce multi-line output."""
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation())
+        s = str(T)
+        self.assertGreater(s.count("\n"), 0)
+
+    def test_str_identity(self):
+        T = Transformation()
+        s = str(T)
+        self.assertIn("0.000000", s)
+
+
+class TestHPointReprStr(unittest.TestCase):
+    """Test __repr__ and __str__ for HPoint (pre-existing but verify consistency)."""
+
+    def test_repr_contains_class_name(self):
+        p = HPoint(1.0, 2.0, 3.0)
+        self.assertIn("HPoint", repr(p))
+
+    def test_str_contains_coordinates(self):
+        p = HPoint(1.0, 2.0, 3.0)
+        s = str(p)
+        self.assertIn("1.0", s)
+        self.assertIn("2.0", s)
+        self.assertIn("3.0", s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,294 @@
+"""Tests for serialization methods (to_dict, from_dict, to_json, from_json, to_csv, from_csv)."""
+
+import json
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from se3kit.hpoint import HPoint
+from se3kit.rotation import Rotation
+from se3kit.transformation import Transformation
+from se3kit.translation import Translation
+
+
+class TestTranslationSerialization(unittest.TestCase):
+    """Test serialization for Translation."""
+
+    def test_to_dict_keys(self):
+        t = Translation([1.0, 2.0, 3.0])
+        d = t.to_dict()
+        self.assertIn("type", d)
+        self.assertIn("xyz", d)
+        self.assertEqual(d["type"], "Translation")
+
+    def test_to_dict_native_types(self):
+        """Verify dict values are native Python floats, not numpy."""
+        t = Translation([1.0, 2.0, 3.0])
+        d = t.to_dict()
+        for v in d["xyz"]:
+            self.assertIsInstance(v, float)
+
+    def test_dict_roundtrip(self):
+        t = Translation([0.5, -0.25, 1.0])
+        t2 = Translation.from_dict(t.to_dict())
+        self.assertTrue(Translation.are_close(t, t2, tol=1e-12))
+
+    def test_from_dict_missing_key(self):
+        with self.assertRaises(ValueError):
+            Translation.from_dict({"bad": [1, 2, 3]})
+
+    def test_json_roundtrip(self):
+        t = Translation([0.5, -0.25, 1.0])
+        t2 = Translation.from_json(t.to_json())
+        self.assertTrue(Translation.are_close(t, t2, tol=1e-12))
+
+    def test_json_is_valid(self):
+        t = Translation([1.0, 2.0, 3.0])
+        j = t.to_json()
+        parsed = json.loads(j)
+        self.assertEqual(parsed["type"], "Translation")
+
+    def test_csv_roundtrip(self):
+        t = Translation([0.5, -0.25, 1.0])
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            t.to_csv(path)
+            t2 = Translation.from_csv(path)
+            self.assertTrue(Translation.are_close(t, t2, tol=1e-12))
+        finally:
+            os.unlink(path)
+
+    def test_csv_no_header(self):
+        t = Translation([1.0, 2.0, 3.0])
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            t.to_csv(path, header=False)
+            t2 = Translation.from_csv(path)
+            self.assertTrue(Translation.are_close(t, t2, tol=1e-12))
+        finally:
+            os.unlink(path)
+
+    def test_csv_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            Translation.from_csv("/nonexistent/path/file.csv")
+
+    def test_zero_translation_roundtrip(self):
+        t = Translation()
+        t2 = Translation.from_dict(t.to_dict())
+        self.assertTrue(Translation.are_close(t, t2, tol=1e-12))
+
+
+class TestRotationSerialization(unittest.TestCase):
+    """Test serialization for Rotation."""
+
+    def test_to_dict_keys(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        d = r.to_dict()
+        self.assertIn("type", d)
+        self.assertIn("quaternion_xyzw", d)
+        self.assertIn("rpy_rad", d)
+        self.assertIn("matrix", d)
+        self.assertEqual(d["type"], "Rotation")
+
+    def test_to_dict_native_types(self):
+        """Verify all values are native Python types, not numpy."""
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        d = r.to_dict()
+        for v in d["quaternion_xyzw"]:
+            self.assertIsInstance(v, float)
+        for v in d["rpy_rad"]:
+            self.assertIsInstance(v, float)
+        # Matrix rows
+        for row in d["matrix"]:
+            for v in row:
+                self.assertIsInstance(v, float)
+
+    def test_dict_roundtrip_via_matrix(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        r2 = Rotation.from_dict(r.to_dict())
+        self.assertTrue(Rotation.are_close(r, r2, tol=1e-10))
+
+    def test_dict_roundtrip_via_quaternion(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        d = r.to_dict()
+        del d["matrix"]
+        r2 = Rotation.from_dict(d)
+        self.assertTrue(Rotation.are_close(r, r2, tol=1e-10))
+
+    def test_dict_roundtrip_via_rpy(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        d = r.to_dict()
+        del d["matrix"]
+        del d["quaternion_xyzw"]
+        r2 = Rotation.from_dict(d)
+        self.assertTrue(Rotation.are_close(r, r2, tol=1e-6))
+
+    def test_from_dict_missing_keys(self):
+        with self.assertRaises(ValueError):
+            Rotation.from_dict({"type": "Rotation"})
+
+    def test_json_roundtrip(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        r2 = Rotation.from_json(r.to_json())
+        self.assertTrue(Rotation.are_close(r, r2, tol=1e-10))
+
+    def test_identity_roundtrip(self):
+        r = Rotation()
+        r2 = Rotation.from_dict(r.to_dict())
+        self.assertTrue(r2.is_identity())
+
+    def test_csv_roundtrip_quaternion(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            r.to_csv(path, fmt="quaternion")
+            r2 = Rotation.from_csv(path, fmt="quaternion")
+            self.assertTrue(Rotation.are_close(r, r2, tol=1e-10))
+        finally:
+            os.unlink(path)
+
+    def test_csv_roundtrip_rpy_rad(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            r.to_csv(path, fmt="rpy_rad")
+            r2 = Rotation.from_csv(path, fmt="rpy_rad")
+            self.assertTrue(Rotation.are_close(r, r2, tol=1e-6))
+        finally:
+            os.unlink(path)
+
+    def test_csv_roundtrip_rpy_deg(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            r.to_csv(path, fmt="rpy_deg")
+            r2 = Rotation.from_csv(path, fmt="rpy_deg")
+            self.assertTrue(Rotation.are_close(r, r2, tol=1e-4))
+        finally:
+            os.unlink(path)
+
+    def test_csv_roundtrip_matrix(self):
+        r = Rotation.from_rpy([0.1, 0.2, 0.3])
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            r.to_csv(path, fmt="matrix")
+            r2 = Rotation.from_csv(path, fmt="matrix")
+            self.assertTrue(Rotation.are_close(r, r2, tol=1e-10))
+        finally:
+            os.unlink(path)
+
+
+class TestTransformationSerialization(unittest.TestCase):
+    """Test serialization for Transformation."""
+
+    def test_to_dict_keys(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation())
+        d = T.to_dict()
+        self.assertIn("type", d)
+        self.assertIn("translation", d)
+        self.assertIn("rotation", d)
+        self.assertIn("matrix", d)
+        self.assertEqual(d["type"], "Transformation")
+
+    def test_dict_roundtrip_via_matrix(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation.from_rpy([0.1, 0.2, 0.3]))
+        T2 = Transformation.from_dict(T.to_dict())
+        self.assertTrue(Transformation.are_close(T, T2))
+
+    def test_dict_roundtrip_via_components(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation.from_rpy([0.1, 0.2, 0.3]))
+        d = T.to_dict()
+        del d["matrix"]
+        T2 = Transformation.from_dict(d)
+        self.assertTrue(Transformation.are_close(T, T2))
+
+    def test_from_dict_missing_keys(self):
+        with self.assertRaises(ValueError):
+            Transformation.from_dict({"type": "Transformation"})
+
+    def test_json_roundtrip(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation.from_rpy([0.1, 0.2, 0.3]))
+        T2 = Transformation.from_json(T.to_json())
+        self.assertTrue(Transformation.are_close(T, T2))
+
+    def test_json_is_valid(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation())
+        j = T.to_json()
+        parsed = json.loads(j)
+        self.assertEqual(parsed["type"], "Transformation")
+
+    def test_csv_roundtrip_quaternion(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation.from_rpy([0.1, 0.2, 0.3]))
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            T.to_csv(path, rotation_format="quaternion")
+            T2 = Transformation.from_csv(path, rotation_format="quaternion")
+            self.assertTrue(Transformation.are_close(T, T2))
+        finally:
+            os.unlink(path)
+
+    def test_csv_roundtrip_rpy(self):
+        T = Transformation(Translation([1.0, 2.0, 3.0]), Rotation.from_rpy([0.1, 0.2, 0.3]))
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            path = f.name
+        try:
+            T.to_csv(path, rotation_format="rpy_rad")
+            T2 = Transformation.from_csv(path, rotation_format="rpy_rad")
+            self.assertTrue(Transformation.are_close(T, T2, rot_tol=1e-4))
+        finally:
+            os.unlink(path)
+
+    def test_identity_roundtrip(self):
+        T = Transformation()
+        T2 = Transformation.from_dict(T.to_dict())
+        self.assertTrue(Transformation.are_close(T, T2))
+
+
+class TestHPointSerialization(unittest.TestCase):
+    """Test serialization for HPoint."""
+
+    def test_to_dict_keys(self):
+        p = HPoint(1.0, 2.0, 3.0)
+        d = p.to_dict()
+        self.assertIn("type", d)
+        self.assertIn("xyz", d)
+        self.assertEqual(d["type"], "HPoint")
+
+    def test_to_dict_native_types(self):
+        p = HPoint(1.0, 2.0, 3.0)
+        d = p.to_dict()
+        for v in d["xyz"]:
+            self.assertIsInstance(v, float)
+
+    def test_dict_roundtrip(self):
+        p = HPoint(1.5, -2.5, 3.0)
+        p2 = HPoint.from_dict(p.to_dict())
+        np.testing.assert_allclose(p.xyz, p2.xyz, atol=1e-12)
+
+    def test_from_dict_missing_key(self):
+        with self.assertRaises(ValueError):
+            HPoint.from_dict({"bad": [1, 2, 3]})
+
+    def test_json_roundtrip(self):
+        p = HPoint(1.5, -2.5, 3.0)
+        p2 = HPoint.from_json(p.to_json())
+        np.testing.assert_allclose(p.xyz, p2.xyz, atol=1e-12)
+
+    def test_json_is_valid(self):
+        p = HPoint(1.0, 2.0, 3.0)
+        j = p.to_json()
+        parsed = json.loads(j)
+        self.assertEqual(parsed["type"], "HPoint")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add __repr__ (eval-reconstructable) and __str__ (human-friendly) to Rotation, Translation, and Transformation
- Add to_dict/from_dict, to_json/from_json for all 4 core classes (Rotation, Translation, Transformation, HPoint)
- Add to_csv/from_csv for Rotation, Translation, Transformation with configurable rotation formats (quaternion, rpy_rad, rpy_deg, matrix)
- All dict/JSON values use native Python float (no numpy scalars)
- 56 new tests across test_repr_str.py and test_serialization.py